### PR TITLE
Update deprecated syntax for res.send method

### DIFF
--- a/_example/dist/server/app.js
+++ b/_example/dist/server/app.js
@@ -42,7 +42,7 @@ app.use(function(req, res, next) {
 if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
-    res.send('error', {
+    res.send({
       message: err.message,
       error: err
     });
@@ -53,7 +53,7 @@ if (app.get('env') === 'development') {
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
-  res.send('error', {
+  res.send({
     message: err.message,
     error: {}
   });

--- a/_example/src/server/app.js
+++ b/_example/src/server/app.js
@@ -42,7 +42,7 @@ app.use(function(req, res, next) {
 if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
-    res.send('error', {
+    res.send({
       message: err.message,
       error: err
     });
@@ -53,7 +53,7 @@ if (app.get('env') === 'development') {
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
-  res.send('error', {
+  res.send({
     message: err.message,
     error: {}
   });

--- a/app/templates/src/server/app.js
+++ b/app/templates/src/server/app.js
@@ -42,7 +42,7 @@ app.use(function(req, res, next) {
 if (app.get('env') === 'development') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
-    res.send('error', {
+    res.send({
       message: err.message,
       error: err
     });
@@ -53,7 +53,7 @@ if (app.get('env') === 'development') {
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
-  res.send('error', {
+  res.send({
     message: err.message,
     error: {}
   });


### PR DESCRIPTION
The current syntax returns:

`express deprecated res.send(status, body): Use res.status(status).send(body) instead src/server/app.js:45:9`
